### PR TITLE
 Fix local import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ after their package names and `bq_table_name` options.
 If you do not already have the standard google protobuf libraries in your `proto_path`, you'll need to specify them directly on the command line (and potentially need to copy `bq_schema.proto` into a proto_path directory as well), like this:
 
 ```sh
-protc --bq-schema_out=path/to/out/dir foo.proto --proto_path=. --proto_path=<path_to_google_proto_folder>/src
+protoc --bq-schema_out=path/to/out/dir foo.proto --proto_path=. --proto_path=<path_to_google_proto_folder>/src
 ```
 
 ### Example

--- a/bq_table_name.proto
+++ b/bq_table_name.proto
@@ -20,7 +20,7 @@ option go_package = "protos";
 import "google/protobuf/descriptor.proto";
 
 extend google.protobuf.MessageOptions {
-  // Sepcified a name of table in BigQuery for the message.
+  // Specified a name of table in BigQuery for the message.
   // Indicates the message is a type of record to be stored into BigQuery.
   //
   // The field number is a globally unique id for this option, assigned by

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"path"
 	"strings"
 
-	"./protos"
+	"github.com/GoogleCloudPlatform/protoc-gen-bq-schema/protos"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"


### PR DESCRIPTION
The import, `./protos`, was breaking in my local environment. I
would suppose it might be breaking for other people too.

The specific error:
`local import in non-local package`

This change simply makes the import non-local. It should essentially
be equivalent, except for situations where the package is forked.